### PR TITLE
Add -lsuitesparseconfig to link statement.

### DIFF
--- a/superlu.rb
+++ b/superlu.rb
@@ -44,7 +44,7 @@ class Superlu < Formula
     # should be in /usr/local/lib/ and libblas in /Applications/Xcode.app/
     # Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
     # MacOSX10.8.sdk/usr/lib/
-    deps = %w[-lcolamd -lblas]
+    deps = %w[-lcolamd -lblas -lsuitesparseconfig]
 
     # build using the modified Makefile; we only need the library
     # so just build the source directory


### PR DESCRIPTION
This fixed a link problem, probably due to new version of SuiteSparse using a new library (libsuitesparseconfig).
